### PR TITLE
Fix SSDP discover

### DIFF
--- a/custom_components/samsungtv_encrypted/media_player.py
+++ b/custom_components/samsungtv_encrypted/media_player.py
@@ -463,6 +463,8 @@ class SamsungTVDevice(MediaPlayerDevice):
         upnp_ports = [None] * len(self._urns)
         upnp_paths = [None] * len(self._urns)
         for entry in scan(timeout):
+            if entry.location is None:
+                continue
             if entry.location.startswith('http://{}'.format(self._config['host'])):
                 for i in range(len(self._urns)):
                     if entry.st == self._urns[i]:


### PR DESCRIPTION
Sometimes scan result is empty, we can ignore it.
Fixes: https://github.com/sermayoral/ha-samsungtv-encrypted/issues/25