### PR TITLE
Don't try to set volume if it's not possible

### DIFF
--- a/custom_components/samsungtv_encrypted/media_player.py
+++ b/custom_components/samsungtv_encrypted/media_player.py
@@ -365,11 +365,12 @@ class SamsungTVDevice(MediaPlayerEntity):
 
     def set_volume_level(self, volume):
         """Volume up the media player."""
-        volset = str(round(volume * 100))
+        if self._upnp_ports and self._upnp_paths and self._urns:
+            volset = str(round(volume * 100))
 
-        self.SendSOAP(self._upnp_ports[0], self._upnp_paths[0], self._urns[0], 'SetVolume',
-                      '<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>' + volset + '</DesiredVolume>',
-                      '')
+            self.SendSOAP(self._upnp_ports[0], self._upnp_paths[0], self._urns[0], 'SetVolume',
+                          '<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>' + volset + '</DesiredVolume>',
+                          '')
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Support changing a channel."""


### PR DESCRIPTION
Was having issues particularly when modifying scenes. `upnp_ports`,
`upnp_paths` and `urns` are sometimes not set so throws an error. This
guards against that