### PR TITLE
better get_token help message

### DIFF
--- a/custom_components/samsungtv_encrypted/get_token.py
+++ b/custom_components/samsungtv_encrypted/get_token.py
@@ -1,21 +1,33 @@
-import sys, getopt
+import sys
+import getopt
 
 from PySmartCrypto.pysmartcrypto import PySmartCrypto
+
+help_msg = '''
+Usage: get_token.py [options]
+
+Available options:
+
+--ip, -i \tSmart TV IP address
+--port, -p \tSmart TV port
+-h \t\t Show this help message
+'''
+
 
 def main(argv):
     ip = ''
     port = ''
     try:
-        opts, args = getopt.getopt(argv,"hi:p:",["ip=","port="])
+        opts, args = getopt.getopt(argv, "hi:p:", ["ip=", "port="])
     except getopt.GetoptError:
-        print( 'get_token.py -ip <ip> -port <port>')
+        print(help_msg)
         sys.exit(2)
     if len(opts) == 0:
-        print('get_token.py -ip <ip> -port <port>')
+        print(help_msg)
         sys.exit()
     for opt, arg in opts:
         if opt == '-h':
-            print ('get_token.py -ip <ip> -port <port>')
+            print(help_msg)
             sys.exit()
         elif opt in ("-i", "--ip"):
             ip = arg
@@ -23,5 +35,6 @@ def main(argv):
             port = arg
     PySmartCrypto(ip, port)
 
+
 if __name__ == "__main__":
-   main(sys.argv[1:])
+    main(sys.argv[1:])


### PR DESCRIPTION
Hi @sermayoral,
first of all, thank you very much for bringing this awesome integration to the Home Assistant community. 🚀 

I improved the help message displayed when executing `get_token.py` with no flags or when using the `-h` flag.
Not a huge issue, but I had troubles running the script so I thought a more detailed message would help new users to get the token for their TV.