### PR TITLE
User supplied port in connection urls

### DIFF
--- a/custom_components/samsungtv_encrypted/PySmartCrypto/pysmartcrypto.py
+++ b/custom_components/samsungtv_encrypted/PySmartCrypto/pysmartcrypto.py
@@ -91,9 +91,9 @@ class PySmartCrypto():
 
     def connect(self):
         millis = int(round(time.time() * 1000))
-        step4_url = 'http://' + self._host + ':8000/socket.io/1/?t=' + str(millis)
+        step4_url = 'http://' + self._host + ':'+self._port+'/socket.io/1/?t=' + str(millis)
         websocket_response = requests.get(step4_url)
-        websocket_url = 'ws://' + self._host + ':8000/socket.io/1/websocket/' + websocket_response.text.split(':')[0]
+        websocket_url = 'ws://' + self._host + ':'+self._port+'/socket.io/1/websocket/' + websocket_response.text.split(':')[0]
         # print(websocket_url)
         # pairs to this app with this command.
         connection = websocket.create_connection(websocket_url)


### PR DESCRIPTION
Hi @sermayoral,
while trying to connect a J series TV (see issue #62) I took a deeper look in the PySmartCrypto code and found that the user supplied port is not being used when pairing with the device:

```
step4_url = 'http://' + self._host + ':8000/socket.io/1/?t=' + str(millis)
...
websocket_url = 'ws://' + self._host + ':8000/socket.io/1/websocket/' + websocket_response.text.split(':')[0]
```
Instead the hardcoded value `8000` is used.

This PR implement the insertion of user supplied port into the urls to possibly solve many connection issues experienced by different users (it should partially address #21 ).