### PR TITLE
Hardcoded ports in step4 and websocket connections

### DIFF
--- a/custom_components/samsungtv_encrypted/PySmartCrypto/pysmartcrypto.py
+++ b/custom_components/samsungtv_encrypted/PySmartCrypto/pysmartcrypto.py
@@ -91,9 +91,9 @@ class PySmartCrypto():
 
     def connect(self):
         millis = int(round(time.time() * 1000))
-        step4_url = 'http://' + self._host + ':'+self._port+'/socket.io/1/?t=' + str(millis)
+        step4_url = 'http://' + self._host + ':8000/socket.io/1/?t=' + str(millis)
         websocket_response = requests.get(step4_url)
-        websocket_url = 'ws://' + self._host + ':'+self._port+'/socket.io/1/websocket/' + websocket_response.text.split(':')[0]
+        websocket_url = 'ws://' + self._host + ':8000/socket.io/1/websocket/' + websocket_response.text.split(':')[0]
         # print(websocket_url)
         # pairs to this app with this command.
         connection = websocket.create_connection(websocket_url)

--- a/custom_components/samsungtv_encrypted/PySmartCrypto/pysmartcrypto.py
+++ b/custom_components/samsungtv_encrypted/PySmartCrypto/pysmartcrypto.py
@@ -94,7 +94,6 @@ class PySmartCrypto():
         step4_url = 'http://' + self._host + ':8000/socket.io/1/?t=' + str(millis)
         websocket_response = requests.get(step4_url)
         websocket_url = 'ws://' + self._host + ':8000/socket.io/1/websocket/' + websocket_response.text.split(':')[0]
-        # print(websocket_url)
         # pairs to this app with this command.
         connection = websocket.create_connection(websocket_url)
         connection.send('1::/com.samsung.companion')


### PR DESCRIPTION
Hi @sermayoral,

After a user report in #21, who wasn't able to connect to its TV after the latest commit, and further reading the code in other SmartCrypto implementations, I checked that we've to revert ports for the connections performed in the `connect` method to the hardcoded value `8000`.

I'm sorry for my previous mistake, this PR will fix it. :)