### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/samsungtv_encrypted/manifest.json
+++ b/custom_components/samsungtv_encrypted/manifest.json
@@ -2,9 +2,9 @@
   "domain": "samsungtv_encrypted",
   "name": "SamsungTV Encrypted",
   "documentation": "https://github.com/sermayoral/ha-samsungtv-encrypted",
-  "requirements": ["wakeonlan==1.1.6", "beautifulsoup4==4.6.0", "netdisco==2.8.3"],
+  "requirements": ["wakeonlan==1.1.6", "beautifulsoup4==4.6.0", "netdisco>=2.8.3"],
   "dependencies": [],
   "codeowners": ["@sermayoral"],
   "homeassistant": "2021.3.0",
-  "version": "v3.2"
+  "version": "v3.3"
 }


### PR DESCRIPTION
Netdisco is EOL, but HA >= 2021.8.0 requires version 2.9.0, which is functionally equivalent to 2.8.3